### PR TITLE
xarray version workaround

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     "entrypoints",
     "numpy>=1.16.5, !=1.21.*",
     "pandas>=1.2.0, !=1.3.0",
-    "xarray>=0.17.0, !=0.18.*",
+    "xarray==0.17.0",
     "netcdf4",
 ]
 


### PR DESCRIPTION
Some methods in xarray 0.19.0 return a DataArray where they used to return an appropriate subclass of DataAssembly.