### PR TITLE
Python netCDF4 version 1.6.0 error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "numpy>=1.16.5, !=1.21.*",
     "pandas>=1.2.0, !=1.3.0",
     "xarray==0.17.0",
-    "netcdf4",
+    "netcdf4==1.5.8",
 ]
 
 setup(


### PR DESCRIPTION
Python netCDF4 version 1.6.0 causes an error:  RuntimeError: NetCDF:  Filter error: bad id or parameters or duplicate filter.