### PR TITLE
disallow xarray 2022.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     "entrypoints",
     "numpy",
     "pandas",
-    "xarray!=2022.06.0",  # 2022.06.0 has a bug which breaks BrainIO:  https://github.com/pydata/xarray/issues/6836
+    "xarray!=2022.6.0,!=2022.9.0",  # 2022.{6,9} have a groupby bug: https://github.com/pydata/xarray/issues/6836
     "netcdf4!=1.6.0",  # https://github.com/Unidata/netcdf4-python/issues/1175,
 ]
 


### PR DESCRIPTION
it still has the bug introduced in 2022.6.0 https://github.com/pydata/xarray/issues/6836