### PR TITLE
remove dask dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ requirements = [
     "pandas",
     "xarray!=2022.6.0,!=2022.9.0,!=2022.10.0",  # 6-10 have a groupby bug: https://github.com/pydata/xarray/issues/6836
     "netcdf4!=1.6.0",  # https://github.com/Unidata/netcdf4-python/issues/1175,
-    "dask;python_version>'3.7'",
 ]
 
 setup(


### PR DESCRIPTION
dask leads to infinite hang for brain-score language, see https://github.com/brain-score/language/pull/99