### PR TITLE
disallow xarray 2022.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ requirements = [
     "entrypoints",
     "numpy",
     "pandas",
-    "xarray!=2022.6.0,!=2022.9.0,!=2022.10.0",  # 6-10 have a groupby bug: https://github.com/pydata/xarray/issues/6836
+    "xarray!=2022.6.0,!=2022.9.0,!=2022.10.0,!=2022.11",  # 6-11 have a groupby bug:
+    # https://github.com/pydata/xarray/issues/6836
     "netcdf4!=1.6.0",  # https://github.com/Unidata/netcdf4-python/issues/1175,
 ]
 

--- a/tests/test_assemblies.py
+++ b/tests/test_assemblies.py
@@ -256,7 +256,7 @@ class TestPlainGroupy:
             },
             dims=("a", "b")
         )
-        d = gather_indexes(d)
+        d = d.set_index(a=['greek', 'colors'], b=['compass', 'integer'])
         g = d.groupby('greek')
         # with xarray==2022.06.0, the following line fails with:
         # ValueError: conflicting multi-index level name 'greek' with dimension 'greek'


### PR DESCRIPTION
new xarray version _still_ has the groupby bug https://app.travis-ci.com/github/brain-score/language/jobs/588010597 https://github.com/pydata/xarray/issues/6836