### PR TITLE
remove excessive BEGIN/END logging

### DIFF
--- a/brainio/assemblies.py
+++ b/brainio/assemblies.py
@@ -438,10 +438,7 @@ def gather_indexes(assembly):
         if coord_names:
             coords_d[dim] = coord_names
     if coords_d:
-        identifier = assembly.attrs.get('identifier', 'assembly')
-        _logger.debug(f'BEGIN set_index on {identifier}')
         assembly = assembly.set_index(append=True, **coords_d)
-        _logger.debug(f'END   set_index on {identifier}')
     return assembly
 
 


### PR DESCRIPTION
the constant `BEGIN set_index` and `END   set_index` logging is too excessive