### PR TITLE
pin xarray at <2022.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ requirements = [
     "entrypoints",
     "numpy",
     "pandas",
-    "xarray!=2022.6.0,!=2022.9.0,!=2022.10.0,!=2022.11",  # 6-11 have a groupby bug:
-    # https://github.com/pydata/xarray/issues/6836
+    "xarray<2022.6",  # groupby bug was introduced in index refactor: https://github.com/pydata/xarray/issues/6836
     "netcdf4!=1.6.0",  # https://github.com/Unidata/netcdf4-python/issues/1175,
 ]
 


### PR DESCRIPTION
This will save us from having to exclude versions every month until https://github.com/pydata/xarray/issues/6836 is resolved