### PR TITLE
DataFrame.append removed from pandas 2.0.0

### DIFF
--- a/brainio/lookup.py
+++ b/brainio/lookup.py
@@ -152,7 +152,8 @@ def append(catalog_identifier, object_identifier, cls, lookup_type,
                     f"Trying to add duplicate identifier {object_lookup['identifier']}, existing {duplicates}")
     # append and save
     add_lookup = pd.DataFrame({key: [value] for key, value in object_lookup.items()})
-    catalog = catalog.append(add_lookup)
+    # catalog = catalog.append(add_lookup)
+    catalog = pd.concat((catalog, add_lookup))
     catalog.to_csv(catalog_path, index=False)
     _catalogs[catalog_identifier] = catalog
     return catalog


### PR DESCRIPTION
DataFrame.append has been removed from the pandas API.  Docs recommend using concat instead.