### PR TITLE
Upload tagging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         "tests": [
             "pytest",
             "imageio",
+            "unittest",
+            "moto"
         ],
     },
     license="MIT license",


### PR DESCRIPTION
This PR adds functionality to find the username of the user uploading a file, and then tags the upload with the user's username.

This is then used within our bucket policy to allow for users to retrieve data if their username matches the upload tag. A tag can only be created on initial upload, and users will not be able to modify the tag, allowing for maximum security.