### PR TITLE
Update fetch to new S3 file structure

### DIFF
--- a/brainio/fetch.py
+++ b/brainio/fetch.py
@@ -63,10 +63,13 @@ class BotoFetcher(Fetcher):
             self.bucketname = split_path[0]
             self.relative_path = os.path.join(*(split_path[1:]))
         self.extra_args = {"VersionId": version_id} if version_id else None
-        self.output_filename = os.path.join(self.local_dir_path, self.relative_path)
+        self.output_filename = os.path.join(self.local_dir_path, os.path.basename(self.relative_path))
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(self.output_filename), exist_ok=True)
         self._logger = logging.getLogger(fullname(self))
 
     def fetch(self):
+        # Ensure the directory path for output_filename exists
         if not os.path.exists(self.output_filename):
             self.download_boto()
         return self.output_filename


### PR DESCRIPTION
Do not merge yet.

Updates the output_filename to avoid new nested file structure as a result of Quest monolithic S3 bucket for brainscore.

**Without the change to output filename**
![image](https://github.com/user-attachments/assets/ac6c4376-acc4-4332-afa0-6a720801f93d)

**With the change to output filename
![image](https://github.com/user-attachments/assets/ab0191e9-78e1-4d0c-bb91-fef7cddf5db6)
